### PR TITLE
bump `aeson` upper version bound

### DIFF
--- a/generic-override-aeson/generic-override-aeson.cabal
+++ b/generic-override-aeson/generic-override-aeson.cabal
@@ -33,7 +33,7 @@ library
   hs-source-dirs:
       src
   build-depends:
-      aeson >=1.4 && <1.6
+      aeson >=1.4 && <2.1
     , base >=4.7 && <5
     , generic-override
   default-language: Haskell2010
@@ -48,7 +48,7 @@ test-suite generic-override-aeson-test
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      aeson >=1.4 && <1.6
+      aeson >=1.4 && <2.1
     , base >=4.7 && <5
     , generic-override
     , generic-override-aeson

--- a/generic-override-aeson/generic-override-aeson.cabal
+++ b/generic-override-aeson/generic-override-aeson.cabal
@@ -33,7 +33,7 @@ library
   hs-source-dirs:
       src
   build-depends:
-      aeson >=1.4 && <2.1
+      aeson >=1.4 && <3
     , base >=4.7 && <5
     , generic-override
   default-language: Haskell2010
@@ -48,7 +48,7 @@ test-suite generic-override-aeson-test
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      aeson >=1.4 && <2.1
+      aeson >=1.4 && <3
     , base >=4.7 && <5
     , generic-override
     , generic-override-aeson

--- a/generic-override-aeson/package.yaml
+++ b/generic-override-aeson/package.yaml
@@ -16,7 +16,7 @@ extra-source-files:
 
 dependencies:
 - base >= 4.7 && < 5
-- aeson >= 1.4 && < 2.1
+- aeson >= 1.4 && < 3
 - generic-override
 
 library:

--- a/generic-override-aeson/package.yaml
+++ b/generic-override-aeson/package.yaml
@@ -16,7 +16,7 @@ extra-source-files:
 
 dependencies:
 - base >= 4.7 && < 5
-- aeson >= 1.4 && < 1.6
+- aeson >= 1.4 && < 2.1
 - generic-override
 
 library:


### PR DESCRIPTION
`stack test` succeeds:
```
generic-override-aeson> Finished in 0.0007 seconds
generic-override-aeson> 7 examples, 0 failures
generic-override-aeson> Test suite generic-override-aeson-test passed
Completed 18 action(s).
```

`cabal test all` succeeds 
```
1 of 1 test suites (1 of 1 test cases) passed.
```
with `cabal.project`:
```
packages:
  generic-override/
  generic-override-aeson/

constraints:
  aeson >=2.0.1.0
```