### PR TITLE
Sum type and kind override support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .stack-work/
 *~
+*.swp

--- a/generic-override/generic-override.cabal
+++ b/generic-override/generic-override.cabal
@@ -1,8 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.33.0.
 --
 -- see: https://github.com/sol/hpack
+--
+-- hash: 826716a7af5af9e3b3ed5bc07a6a669bc1e91c109f50eff9799be1d50aaa881a
 
 name:           generic-override
 version:        0.2.0.1
@@ -42,6 +44,7 @@ test-suite generic-override-test
   type: exitcode-stdio-1.0
   main-is: Test.hs
   other-modules:
+      Encode
       Paths_generic_override
   hs-source-dirs:
       test

--- a/generic-override/test/Encode.hs
+++ b/generic-override/test/Encode.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+module Encode where
+
+import Data.Coerce
+import Data.List
+import Data.Override.Internal
+import GHC.Generics
+
+class Encode a where
+  encode :: a -> String
+  default encode :: (Generic a, GEncode (Rep a)) => a -> String
+  encode = gencode . from
+
+instance
+  ( Generic a
+  , GOverride xs (Rep a)
+  , GEncode (Rep (Override a xs))
+  ) => Encode (Override a xs)
+
+instance
+  ( u ~ Using ms a xs
+  , Coercible a u
+  , Encode u
+  ) => Encode (Overridden ms a xs)
+  where
+  encode = encode @u . coerce
+
+class GEncode f where
+  gencode :: f a -> String
+
+instance (GEncode f) => GEncode (M1 D x f) where
+  gencode (M1 f) = gencode f
+
+instance (GEncode f, Constructor c) => GEncode (M1 C c f) where
+  gencode m@(M1 f) = conName m <> ":" <> gencode f
+
+instance (GEncode f, GEncode g) => GEncode (f :*: g) where
+  gencode (f :*: g) = gencode f <> "," <> gencode g
+
+instance (GEncode f, GEncode g) => GEncode (f :+: g) where
+  gencode = \case
+    L1 f -> gencode f
+    R1 g -> gencode g
+
+instance (GEncode f, Selector s) => GEncode (M1 S s f) where
+  gencode m@(M1 f) =
+    if null (selName m) then
+      gencode f
+    else
+      selName m <> "=" <> gencode f
+
+instance (Encode a) => GEncode (K1 R a) where
+  gencode (K1 a) = encode a
+
+instance GEncode U1 where
+  gencode _ = ""
+
+instance Encode Int where
+  encode = show
+
+instance Encode Char where
+  encode = pure
+
+instance {-# OVERLAPPING #-} Encode String where
+  encode = id
+
+instance (Encode a) => Encode [a] where
+  encode = intercalate "," . map encode
+
+newtype ListOf a = ListOf { unListOf :: [a] }
+
+instance (Encode a) => Encode (ListOf a) where
+  encode = intercalate "," . map encode . unListOf

--- a/generic-override/test/Test.hs
+++ b/generic-override/test/Test.hs
@@ -3,11 +3,13 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 module Main where
 
 import Data.Monoid
 import Data.Override
+import Encode
 import GHC.Generics (Generic)
 import Test.Hspec
 
@@ -20,8 +22,13 @@ main = hspec do
       it "Rec1" testRec1'Monoid
     describe "Eq" do
       it "Rec2" testRec2'Eq
+      it "Sum1" testSum1'Eq
     describe "Ord" do
       it "Rec2" testRec2'Ord
+    describe "Encode" do
+      it "Sum1" testSum1'Encode
+      it "Sum2" testSum2'Encode
+      it "Sum3" testSum3'Encode
 
 -- | Overriding instances by type.
 data Rec1 = Rec1
@@ -70,3 +77,43 @@ testRec2'Ord = do
   (Rec2 "foo" 0 <= Rec2 "bar" 0) `shouldBe` True
   (Rec2 "foo" 1 <= Rec2 "bar" 0) `shouldBe` False
   (Rec2 ""    0 >= Rec2 "bar" 0) `shouldBe` False
+
+-- | Override support for sum types.
+data Sum1 = Sum1String String | Sum1Int Int
+  deriving stock (Show, Generic)
+  deriving (Eq) via (Override Sum1 '[String `As` ByLength])
+  deriving (Encode) via (Override Sum1 '[String `As` ListOf Char])
+
+testSum1'Eq :: IO ()
+testSum1'Eq = do
+  (Sum1String "foo" == Sum1String "bar") `shouldBe` True
+  (Sum1Int 3 == Sum1Int 3) `shouldBe` True
+  (Sum1String "foo" == Sum1String "ba") `shouldBe` False
+  (Sum1String "foo" == Sum1Int 3) `shouldBe` False
+  (Sum1Int 3 == Sum1Int 2) `shouldBe` False
+
+testSum1'Encode :: IO ()
+testSum1'Encode = do
+  encode (Sum1String "foo") `shouldBe` "Sum1String:f,o,o"
+  encode (Sum1Int 1) `shouldBe` "Sum1Int:1"
+
+-- | Override using 'As' which includes a type variable.
+data Sum2 a = Sum2List [a] | Sum2Null
+  deriving stock (Show, Eq, Generic)
+  deriving (Encode) via (Override (Sum2 a) '[[a] `As` ListOf a])
+
+testSum2'Encode :: IO ()
+testSum2'Encode = do
+  encode (Sum2List [1, 2, 3 :: Int]) `shouldBe` "Sum2List:1,2,3"
+  encode (Sum2Null @Int) `shouldBe` "Sum2Null:"
+
+-- | Override using 'As' which uses a kind of @* -> *@. Convenient
+-- so you don't have to apply the type parameter.
+data Sum3 a = Sum3List [a] | Sum3Null
+  deriving stock (Show, Eq, Generic)
+  deriving (Encode) via (Override (Sum3 a) '[[] `As` ListOf])
+
+testSum3'Encode :: IO ()
+testSum3'Encode = do
+  encode (Sum3List [1, 2, 3 :: Int]) `shouldBe` "Sum3List:1,2,3"
+  encode (Sum3Null @Int) `shouldBe` "Sum3Null:"


### PR DESCRIPTION
Adds support for Sum types and overriding instances for higher kinds as a convenience so you can omit the type variables. See the test suite in the diff for examples.