### PR TITLE
Release 0.4.0.0

### DIFF
--- a/generic-override-aeson/CHANGELOG.md
+++ b/generic-override-aeson/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog for generic-override-aeson
 
+## 0.4.0.0
+
+* Add `WithAesonOptions` support
+* Bumping dependency bounds to support generic-override 0.4
+* Because this version of generic-override no longer uses `Overridden` under
+    the hood, this solves a problem where `omitNothingFields` had no effect
+    due to aeson's incoherent `Maybe` instance not being solved. The new
+    encoding solves this problem and `omitNothingFields` works as expected.
+
 ## 0.3.0.0
 
 * Bumping dependency bounds to support generic-override 0.3

--- a/generic-override-aeson/generic-override-aeson.cabal
+++ b/generic-override-aeson/generic-override-aeson.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           generic-override-aeson
-version:        0.3.0.0
+version:        0.4.0.0
 synopsis:       Provides orphan instances necessary for integrating generic-override and aeson
 description:    Please see the README on GitHub at <https://github.com/estatico/generic-override#readme>
 category:       Generics
@@ -37,7 +37,7 @@ library
   build-depends:
       aeson >=1.4 && <3
     , base >=4.7 && <5
-    , generic-override >= 0.3.0.0 && < 0.4
+    , generic-override >= 0.4.0.0 && < 0.5
   default-language: Haskell2010
 
 test-suite generic-override-aeson-test

--- a/generic-override-aeson/generic-override-aeson.cabal
+++ b/generic-override-aeson/generic-override-aeson.cabal
@@ -28,10 +28,12 @@ source-repository head
 library
   exposed-modules:
       Data.Override.Aeson
+      Data.Override.Aeson.Options.Internal
   other-modules:
       Paths_generic_override_aeson
   hs-source-dirs:
       src
+  ghc-options: -Wall
   build-depends:
       aeson >=1.4 && <3
     , base >=4.7 && <5
@@ -46,7 +48,7 @@ test-suite generic-override-aeson-test
       Paths_generic_override_aeson
   hs-source-dirs:
       test
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       aeson >=1.4 && <3
     , base >=4.7 && <5

--- a/generic-override-aeson/src/Data/Override/Aeson.hs
+++ b/generic-override-aeson/src/Data/Override/Aeson.hs
@@ -1,22 +1,16 @@
--- | This module contains only orphan instances. It is only needed to
--- be imported where you are overriding instances for aeson generic derivation.
-
-{-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-module Data.Override.Aeson where
+module Data.Override.Aeson
+  ( WithAesonOptions(..)
+  , AesonOption(..)
+  ) where
 
-import Data.Coerce (Coercible, coerce)
-import Data.Override.Internal (Override, Using)
+import Data.Override (Override(..))
+import Data.Override.Aeson.Options.Internal (AesonOption(..), WithAesonOptions(..))
 import GHC.Generics (Generic, Rep)
+
 import qualified Data.Aeson as Aeson
 
 instance

--- a/generic-override-aeson/src/Data/Override/Aeson.hs
+++ b/generic-override-aeson/src/Data/Override/Aeson.hs
@@ -1,3 +1,6 @@
+-- | The public, stable @generic-override-aeson@ API.
+-- Provides orphan instances for 'Override' as well as customization
+-- for aeson's 'Options' when using @DerivingVia@.
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -7,19 +10,18 @@ module Data.Override.Aeson
   , AesonOption(..)
   ) where
 
+import Data.Aeson
 import Data.Override (Override(..))
 import Data.Override.Aeson.Options.Internal (AesonOption(..), WithAesonOptions(..))
 import GHC.Generics (Generic, Rep)
 
-import qualified Data.Aeson as Aeson
+instance
+  ( Generic (Override a xs)
+  , GToJSON Zero (Rep (Override a xs))
+  , GToEncoding Zero (Rep (Override a xs))
+  ) => ToJSON (Override a xs)
 
 instance
   ( Generic (Override a xs)
-  , Aeson.GToJSON Aeson.Zero (Rep (Override a xs))
-  , Aeson.GToEncoding Aeson.Zero (Rep (Override a xs))
-  ) => Aeson.ToJSON (Override a xs)
-
-instance
-  ( Generic (Override a xs)
-  , Aeson.GFromJSON Aeson.Zero (Rep (Override a xs))
-  ) => Aeson.FromJSON (Override a xs)
+  , GFromJSON Zero (Rep (Override a xs))
+  ) => FromJSON (Override a xs)

--- a/generic-override-aeson/src/Data/Override/Aeson.hs
+++ b/generic-override-aeson/src/Data/Override/Aeson.hs
@@ -15,7 +15,7 @@
 module Data.Override.Aeson where
 
 import Data.Coerce (Coercible, coerce)
-import Data.Override.Internal (Override, Overridden(Overridden), Using)
+import Data.Override.Internal (Override, Using)
 import GHC.Generics (Generic, Rep)
 import qualified Data.Aeson as Aeson
 
@@ -26,21 +26,6 @@ instance
   ) => Aeson.ToJSON (Override a xs)
 
 instance
-  ( Coercible a (Using i a xs)
-  , Aeson.ToJSON (Using i a xs)
-  ) => Aeson.ToJSON (Overridden i a xs)
-  where
-  toJSON = Aeson.toJSON @(Using i a xs) . coerce
-  toEncoding = Aeson.toEncoding @(Using i a xs) . coerce
-
-instance
   ( Generic (Override a xs)
   , Aeson.GFromJSON Aeson.Zero (Rep (Override a xs))
   ) => Aeson.FromJSON (Override a xs)
-
-instance
-  ( Coercible a (Using i a xs)
-  , Aeson.FromJSON (Using i a xs)
-  ) => Aeson.FromJSON (Overridden i a xs)
-  where
-  parseJSON = coerce . Aeson.parseJSON @(Using i a xs)

--- a/generic-override-aeson/src/Data/Override/Aeson.hs
+++ b/generic-override-aeson/src/Data/Override/Aeson.hs
@@ -26,12 +26,12 @@ instance
   ) => Aeson.ToJSON (Override a xs)
 
 instance
-  ( Coercible a (Using ms a xs)
-  , Aeson.ToJSON (Using ms a xs)
-  ) => Aeson.ToJSON (Overridden ms a xs)
+  ( Coercible a (Using i a xs)
+  , Aeson.ToJSON (Using i a xs)
+  ) => Aeson.ToJSON (Overridden i a xs)
   where
-  toJSON = Aeson.toJSON @(Using ms a xs) . coerce
-  toEncoding = Aeson.toEncoding @(Using ms a xs) . coerce
+  toJSON = Aeson.toJSON @(Using i a xs) . coerce
+  toEncoding = Aeson.toEncoding @(Using i a xs) . coerce
 
 instance
   ( Generic (Override a xs)
@@ -39,8 +39,8 @@ instance
   ) => Aeson.FromJSON (Override a xs)
 
 instance
-  ( Coercible a (Using ms a xs)
-  , Aeson.FromJSON (Using ms a xs)
-  ) => Aeson.FromJSON (Overridden ms a xs)
+  ( Coercible a (Using i a xs)
+  , Aeson.FromJSON (Using i a xs)
+  ) => Aeson.FromJSON (Overridden i a xs)
   where
-  parseJSON = coerce . Aeson.parseJSON @(Using ms a xs)
+  parseJSON = coerce . Aeson.parseJSON @(Using i a xs)

--- a/generic-override-aeson/src/Data/Override/Aeson/Options/Internal.hs
+++ b/generic-override-aeson/src/Data/Override/Aeson/Options/Internal.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+module Data.Override.Aeson.Options.Internal where
+
+import Data.Aeson
+import Data.Coerce (coerce)
+import Data.Proxy (Proxy(..))
+import GHC.Generics (Generic, Rep)
+import GHC.TypeLits (KnownSymbol, Symbol, symbolVal)
+
+import qualified Data.Aeson as Aeson
+
+newtype WithAesonOptions (a :: *) (options :: [AesonOption]) = WithAesonOptions a
+
+instance
+  ( ApplyAesonOptions options
+  , Generic a
+  , Aeson.GToJSON Aeson.Zero (Rep a)
+  , Aeson.GToEncoding Aeson.Zero (Rep a)
+  ) => ToJSON (WithAesonOptions a options)
+  where
+  toJSON = coerce $ genericToJSON @a $ applyAesonOptions (Proxy @options) defaultOptions
+  toEncoding = coerce $ genericToEncoding @a $ applyAesonOptions (Proxy @options) defaultOptions
+
+instance
+  ( ApplyAesonOptions options
+  , Generic a
+  , Aeson.GFromJSON Aeson.Zero (Rep a)
+  ) => FromJSON (WithAesonOptions a options)
+  where
+  parseJSON = coerce $ genericParseJSON @a $ applyAesonOptions (Proxy @options) defaultOptions
+
+data AesonOption =
+    AllNullaryToStringTag Bool
+  | OmitNothingFields
+  | SumEncodingTaggedObject Symbol Symbol
+  | SumEncodingUntaggedValue
+  | SumEncodingObjectWithSingleField
+  | SumEncodingTwoElemArray
+  | UnwrapUnaryRecords
+  | TagSingleConstructors
+
+class ApplyAesonOptions (options :: [AesonOption]) where
+  applyAesonOptions :: Proxy options -> Options -> Options
+
+instance ApplyAesonOptions '[] where
+  applyAesonOptions _ = id
+
+instance
+  ( ApplyAesonOption option
+  , ApplyAesonOptions options
+  ) => ApplyAesonOptions (option ': options)
+  where
+  applyAesonOptions _ =
+    applyAesonOption (Proxy @option) . (applyAesonOptions (Proxy @options))
+
+class ApplyAesonOption (option :: AesonOption) where
+  applyAesonOption :: Proxy option -> Options -> Options
+
+instance ApplyAesonOption ('AllNullaryToStringTag 'True) where
+  applyAesonOption _ o = o { allNullaryToStringTag = True }
+
+instance ApplyAesonOption ('AllNullaryToStringTag 'False) where
+  applyAesonOption _ o = o { allNullaryToStringTag = False }
+
+instance ApplyAesonOption 'OmitNothingFields where
+  applyAesonOption _ o = o { omitNothingFields = True }
+
+instance (KnownSymbol k, KnownSymbol v) => ApplyAesonOption ('SumEncodingTaggedObject k v) where
+  applyAesonOption _ o = o { sumEncoding = TaggedObject (symbolVal (Proxy @k)) (symbolVal (Proxy @v)) }
+
+instance ApplyAesonOption 'SumEncodingUntaggedValue where
+  applyAesonOption _ o = o { sumEncoding = UntaggedValue }
+
+instance ApplyAesonOption 'SumEncodingObjectWithSingleField where
+  applyAesonOption _ o = o { sumEncoding = ObjectWithSingleField }
+
+instance ApplyAesonOption 'SumEncodingTwoElemArray where
+  applyAesonOption _ o = o { sumEncoding = TwoElemArray }
+
+instance ApplyAesonOption 'UnwrapUnaryRecords where
+  applyAesonOption _ o = o { unwrapUnaryRecords = True }
+
+instance ApplyAesonOption 'TagSingleConstructors where
+  applyAesonOption _ o = o { tagSingleConstructors = True }

--- a/generic-override-aeson/src/Data/Override/Aeson/Options/Internal.hs
+++ b/generic-override-aeson/src/Data/Override/Aeson/Options/Internal.hs
@@ -1,3 +1,6 @@
+-- | This is the internal generic-override-aeson API and should be considered
+-- unstable and subject to change. In general, you should prefer to use the
+-- public, stable API provided by "Data.Override.Aeson".
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -16,6 +19,8 @@ import GHC.TypeLits (KnownSymbol, Symbol, symbolVal)
 
 import qualified Data.Aeson as Aeson
 
+-- | Use with @DerivingVia@ to override Aeson @Options@ with a type-level
+-- list of 'AesonOption'.
 newtype WithAesonOptions (a :: *) (options :: [AesonOption]) = WithAesonOptions a
 
 instance
@@ -36,16 +41,18 @@ instance
   where
   parseJSON = coerce $ genericParseJSON @a $ applyAesonOptions (Proxy @options) defaultOptions
 
+-- | Provides a type-level subset of fields from 'Options'
 data AesonOption =
-    AllNullaryToStringTag Bool
-  | OmitNothingFields
-  | SumEncodingTaggedObject Symbol Symbol
-  | SumEncodingUntaggedValue
-  | SumEncodingObjectWithSingleField
-  | SumEncodingTwoElemArray
-  | UnwrapUnaryRecords
-  | TagSingleConstructors
+    AllNullaryToStringTag Bool -- ^ Equivalient to @'allNullaryToStringTag' = b@
+  | OmitNothingFields -- ^ Equivalient to @'omitNothingFields' = True@
+  | SumEncodingTaggedObject Symbol Symbol -- ^ Equivalient to @'sumEncoding' = 'TaggedObject' k v@
+  | SumEncodingUntaggedValue -- ^ Equivalient to @'sumEncoding' = 'UntaggedValue'@
+  | SumEncodingObjectWithSingleField -- ^ Equivalient to @'sumEncoding' = 'ObjectWithSingleField'@
+  | SumEncodingTwoElemArray -- ^ Equivalient to @'sumEncoding' = 'TwoElemArray'@
+  | UnwrapUnaryRecords -- ^ Equivalient to @'unwrapUnaryRecords' = True@
+  | TagSingleConstructors -- ^ Equivalient to @'tagSingleConstructors' = True@
 
+-- | Updates 'Options' given a type-level list of 'AesonOption'.
 class ApplyAesonOptions (options :: [AesonOption]) where
   applyAesonOptions :: Proxy options -> Options -> Options
 
@@ -60,6 +67,7 @@ instance
   applyAesonOptions _ =
     applyAesonOption (Proxy @option) . (applyAesonOptions (Proxy @options))
 
+-- | Updates 'Options' given a single type-level 'AesonOption'.
 class ApplyAesonOption (option :: AesonOption) where
   applyAesonOption :: Proxy option -> Options -> Options
 

--- a/generic-override/CHANGELOG.md
+++ b/generic-override/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Changelog for generic-override
 
+## 0.4.0.0
+
+* `At` support for overriding by constructor name and parameter index
+* Simplify encoding by removing `Overridden`
+* Implementation of `Generic` derivation a la `GOverride` now use `INLINE`
+
 ## 0.3.0.0
 
-* 'Override' support for sum types
-* 'As' support for higher kinds up (up to arity 10)
+* `Override` support for sum types
+* `As` support for higher kinds up (up to arity 10)
 
 ## 0.2.0.0
 

--- a/generic-override/generic-override.cabal
+++ b/generic-override/generic-override.cabal
@@ -7,7 +7,7 @@ cabal-version: 1.12
 -- hash: 826716a7af5af9e3b3ed5bc07a6a669bc1e91c109f50eff9799be1d50aaa881a
 
 name:           generic-override
-version:        0.3.0.0
+version:        0.4.0.0
 synopsis:       Provides functionality for overriding instances for generic derivation
 description:    Please see the README on GitHub at <https://github.com/estatico/generic-override#readme>
 category:       Generics

--- a/generic-override/generic-override.cabal
+++ b/generic-override/generic-override.cabal
@@ -36,6 +36,7 @@ library
       Paths_generic_override
   hs-source-dirs:
       src
+  ghc-options: -Wall
   build-depends:
       base >=4.7 && <5
   default-language: Haskell2010
@@ -48,7 +49,7 @@ test-suite generic-override-test
       Paths_generic_override
   hs-source-dirs:
       test
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
     , generic-override

--- a/generic-override/src/Data/Override.hs
+++ b/generic-override/src/Data/Override.hs
@@ -2,8 +2,9 @@
 module Data.Override
   ( Override(Override)
   , As
+  , At
   , With
   ) where
 
-import Data.Override.Internal (Override(Override), As, With)
+import Data.Override.Internal (Override(Override), As, At, With)
 import Data.Override.Instances ()

--- a/generic-override/src/Data/Override/Instances.hs
+++ b/generic-override/src/Data/Override/Instances.hs
@@ -7,7 +7,6 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Data.Override.Instances () where
 
-import Data.Coerce (Coercible, coerce)
 import Data.Function (on)
 import GHC.Generics (Generic(Rep, from, to))
 

--- a/generic-override/src/Data/Override/Instances.hs
+++ b/generic-override/src/Data/Override/Instances.hs
@@ -29,13 +29,6 @@ instance
   where
   (==) = (==) `on` from'
 
-instance
-  ( Coercible a (Using ms a xs)
-  , Eq (Using ms a xs)
-  ) => Eq (Overridden ms a xs)
-  where
-  x == y = (==) @(Using ms a xs) (coerce x) (coerce y)
-
 -- Ord
 
 instance
@@ -44,14 +37,6 @@ instance
   ) => Ord (Override a xs)
   where
   compare = compare `on` from'
-
-instance
-  ( Coercible a (Using ms a xs)
-  , Ord (Using ms a xs)
-  ) => Ord (Overridden ms a xs)
-  where
-  compare x y = compare @(Using ms a xs) (coerce x) (coerce y)
-
 
 -- Semigroup
 
@@ -62,13 +47,6 @@ instance
   where
   x <> y = to (from' x <> from' y)
 
-instance
-  ( Coercible a (Using ms a xs)
-  , Semigroup (Using ms a xs)
-  ) => Semigroup (Overridden ms a xs)
-  where
-  x <> y = coerce $ (<>) @(Using ms a xs) (coerce x) (coerce y)
-
 -- Monoid
 
 instance
@@ -78,11 +56,3 @@ instance
   where
   mempty = to' mempty
   x `mappend` y = to (from' x `mappend` from' y)
-
-instance
-  ( Coercible a (Using ms a xs)
-  , Monoid (Using ms a xs)
-  ) => Monoid (Overridden ms a xs)
-  where
-  mempty = coerce $ mempty @(Using ms a xs)
-  x `mappend` y = coerce $ mappend @(Using ms a xs) (coerce x) (coerce y)

--- a/generic-override/src/Data/Override/Instances.hs
+++ b/generic-override/src/Data/Override/Instances.hs
@@ -8,9 +8,8 @@
 module Data.Override.Instances () where
 
 import Data.Function (on)
+import Data.Override.Internal (Override)
 import GHC.Generics (Generic(Rep, from, to))
-
-import Data.Override.Internal
 
 -- The @foo `on` from'@ idiom is taken from @generic-data@ by Li-yao Xia.
 from' :: Generic a => a -> Rep a ()

--- a/generic-override/src/Data/Override/Internal.hs
+++ b/generic-override/src/Data/Override/Internal.hs
@@ -3,16 +3,19 @@
 -- (e.g. generic-override-aeson). In general, unless you are integrating
 -- some type class with generic-override, you should prefer to use the
 -- public, stable API provided by 'Data.Override'.
-
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -21,7 +24,7 @@
 module Data.Override.Internal where
 
 import GHC.Generics
-import GHC.TypeLits (Symbol)
+import GHC.TypeLits
 
 -- | The feature of this library. For use with DerivingVia.
 -- Apply it to a type @a@ and supply a type-level list of instance
@@ -44,8 +47,12 @@ data As (o :: k) n
 -- | Used to wrap a field into a something of kind @* -> *@, for example another newtype.
 data With (o :: k) (w :: * -> *)
 
+-- | Used to construct a type-level override for the given constructor
+-- name @c@ and parameter index @n@.
+data At (c :: Symbol) (p :: Nat) n
+
 -- | Used at the leaf nodes of a generic 'Rep'
-newtype Overridden (ms :: Maybe Symbol) a (xs :: [*]) = Overridden a
+newtype Overridden (i :: Inspect) a (xs :: [*]) = Overridden a
 
 -- | Unwrap an 'Overridden' value.
 unOverridden :: Overridden ms a xs -> a
@@ -53,86 +60,163 @@ unOverridden (Overridden a) = a
 
 -- | Same as 'override' but for 'Overridden' types.
 overridden
-  :: forall a (ms :: Maybe Symbol) (xs :: [*]) proxy0 proxy1.
-     a -> proxy0 ms -> proxy1 xs -> Overridden ms a xs
+  :: forall a (i :: Inspect) (xs :: [*]) proxy0 proxy1.
+     a -> proxy0 i -> proxy1 xs -> Overridden i a xs
 overridden a _ _ = Overridden a
 
-instance (Generic a, GOverride xs (Rep a)) => Generic (Override a xs) where
-  type Rep (Override a xs) = OverrideRep xs (Rep a)
-  from = overrideFrom @xs . from . unOverride
-  to = Override . to . overrideTo @xs
+instance
+  ( Generic a
+  , GOverride xs (Rep a)
+  ) => Generic (Override a xs)
+  where
+  type Rep (Override a xs) = OverrideRep EmptyInspect xs (Rep a)
+  from = overrideFrom @EmptyInspect @xs . from . unOverride
+  to = Override . to . overrideTo @EmptyInspect @xs
+
+type GOverride = GOverride' EmptyInspect
 
 -- | Type class used to build the 'Generic' instance for 'Override'.
-class GOverride (xs :: [*]) (f :: * -> *) where
-  -- | Analogous to 'Rep'; rewrites the type for a given 'Rep' and injects
-  -- 'Overridden' at the leaves.
-  type OverrideRep xs f :: * -> *
-  overrideFrom :: f x -> OverrideRep xs f x
-  overrideTo :: OverrideRep xs f x -> f x
+class GOverride' (i :: Inspect) (xs :: [*]) (f :: * -> *) where
+  type OverrideRep i xs f :: * -> *
+  overrideFrom :: f x -> OverrideRep i xs f x
+  overrideTo :: OverrideRep i xs f x -> f x
 
-instance (GOverride xs f) => GOverride xs (M1 D c f) where
-  type OverrideRep xs (M1 D c f) = M1 D c (OverrideRep xs f)
-  overrideFrom (M1 x) = M1 (overrideFrom @xs x)
-  overrideTo (M1 x) = M1 (overrideTo @xs x)
+instance (GOverride' i xs f) => GOverride' i xs (M1 D c f) where
+  type OverrideRep i xs (M1 D c f) = M1 D c (OverrideRep i xs f)
+  overrideFrom (M1 x) = M1 (overrideFrom @i @xs x)
+  overrideTo (M1 x) = M1 (overrideTo @i @xs x)
 
-instance (GOverride xs f) => GOverride xs (M1 C c f) where
-  type OverrideRep xs (M1 C c f) = M1 C c (OverrideRep xs f)
-  overrideFrom (M1 x) = M1 (overrideFrom @xs x)
-  overrideTo (M1 x) = M1 (overrideTo @xs x)
+instance
+  ( GOverride' ('Inspect ('Just conName) ms mp) xs f
+  ) => GOverride' ('Inspect ignore ms mp) xs
+        (M1 C ('MetaCons conName conFixity conIsRecord) f)
+  where
+  type OverrideRep ('Inspect ignore ms mp) xs
+        (M1 C ('MetaCons conName conFixity conIsRecord) f) =
+          M1 C
+            ('MetaCons conName conFixity conIsRecord)
+            (OverrideRep ('Inspect ('Just conName) ms mp) xs f)
 
-instance (GOverride xs f, GOverride xs g) => GOverride xs (f :*: g) where
-  type OverrideRep xs (f :*: g) = OverrideRep xs f :*: OverrideRep xs g
-  overrideFrom (f :*: g) = overrideFrom @xs f :*: overrideFrom @xs g
-  overrideTo (f :*: g) = overrideTo @xs f :*: overrideTo @xs g
+  overrideFrom (M1 x) = M1 (overrideFrom @('Inspect ('Just conName) ms mp) @xs x)
+  overrideTo (M1 x) = M1 (overrideTo @('Inspect ('Just conName) ms mp) @xs x)
 
-instance (GOverride xs f, GOverride xs g) => GOverride xs (f :+: g) where
-  type OverrideRep xs (f :+: g) = OverrideRep xs f :+: OverrideRep xs g
+instance
+  ( GOverride' ('Inspect mc ms ('Just 0)) xs f
+  , GOverride' ('Inspect mc ms ('Just 1)) xs g
+  ) => GOverride' ('Inspect mc ms 'Nothing) xs (f :*: g)
+  where
+  type OverrideRep ('Inspect mc ms 'Nothing) xs (f :*: g) =
+    OverrideRep ('Inspect mc ms ('Just 0)) xs f
+      :*: OverrideRep ('Inspect mc ms ('Just 1)) xs g
+
+  overrideFrom (f :*: g) =
+    overrideFrom @('Inspect mc ms ('Just 0)) @xs f
+      :*: overrideFrom @('Inspect mc ms ('Just 1)) @xs g
+
+  overrideTo (f :*: g) =
+    overrideTo @('Inspect mc ms ('Just 0)) @xs f
+      :*: overrideTo @('Inspect mc ms ('Just 1)) @xs g
+
+instance
+  ( GOverride' ('Inspect mc ms ('Just p)) xs f
+  , GOverride' ('Inspect mc ms ('Just (p + 1))) xs g
+  ) => GOverride' ('Inspect mc ms ('Just p)) xs (f :*: g)
+  where
+  type OverrideRep ('Inspect mc ms ('Just p)) xs (f :*: g) =
+    OverrideRep ('Inspect mc ms ('Just p)) xs f
+      :*: OverrideRep ('Inspect mc ms ('Just (p + 1))) xs g
+
+  overrideFrom (f :*: g) =
+    overrideFrom @('Inspect mc ms ('Just p)) @xs f
+      :*: overrideFrom @('Inspect mc ms ('Just (p + 1))) @xs g
+
+  overrideTo (f :*: g) =
+    overrideTo @('Inspect mc ms ('Just p)) @xs f
+      :*: overrideTo @('Inspect mc ms ('Just (p + 1))) @xs g
+
+instance
+  ( GOverride' i xs f
+  , GOverride' i xs g
+  ) => GOverride' i xs (f :+: g)
+  where
+  type OverrideRep i xs (f :+: g) = OverrideRep i xs f :+: OverrideRep i xs g
 
   overrideFrom = \case
-    L1 f -> L1 $ overrideFrom @xs f
-    R1 g -> R1 $ overrideFrom @xs g
+    L1 f -> L1 $ overrideFrom @i @xs f
+    R1 g -> R1 $ overrideFrom @i @xs g
 
   overrideTo = \case
-    L1 f -> L1 $ overrideTo @xs f
-    R1 g -> R1 $ overrideTo @xs g
+    L1 f -> L1 $ overrideTo @i @xs f
+    R1 g -> R1 $ overrideTo @i @xs g
 
-instance GOverride xs (M1 S ('MetaSel ms su ss ds) (K1 R c)) where
-  type OverrideRep xs (M1 S ('MetaSel ms su ss ds) (K1 R c)) =
-    M1 S ('MetaSel ms su ss ds) (K1 R (Overridden ms c xs))
-  overrideFrom (M1 (K1 x)) = M1 (K1 (Overridden @ms x))
-  overrideTo (M1 (K1 (Overridden x))) = M1 (K1 x)
+instance
+  ( GOverride' ('Inspect mc selName mp) xs f
+  ) => GOverride' ('Inspect mc ignore mp) xs (M1 S ('MetaSel selName selSU selSS selDS) f)
+  where
+  type OverrideRep ('Inspect mc ignore mp) xs (M1 S ('MetaSel selName selSU selSS selDS) f) =
+    M1 S ('MetaSel selName selSU selSS selDS) (OverrideRep ('Inspect mc selName mp) xs f)
 
-instance GOverride xs U1 where
-  type OverrideRep xs U1 = U1
+  overrideFrom (M1 x) = M1 (overrideFrom @('Inspect mc selName mp) @xs x)
+  overrideTo (M1 x) = M1 (overrideTo @('Inspect mc selName mp) @xs x)
+
+instance GOverride' ('Inspect mc ms 'Nothing) xs (K1 R a) where
+  type OverrideRep ('Inspect mc ms 'Nothing) xs (K1 R a) =
+    K1 R (Overridden ('Inspect mc ms ('Just 0)) a xs)
+
+  overrideFrom (K1 a) = K1 (Overridden @('Inspect mc ms ('Just 0)) @a @xs a)
+
+  overrideTo (K1 (Overridden a)) = K1 a
+
+instance GOverride' ('Inspect mc ms ('Just p)) xs (K1 R a) where
+  type OverrideRep ('Inspect mc ms ('Just p)) xs (K1 R a) =
+    K1 R (Overridden ('Inspect mc ms ('Just p)) a xs)
+
+  overrideFrom (K1 a) = K1 (Overridden @('Inspect mc ms ('Just p)) @a @xs a)
+
+  overrideTo (K1 (Overridden a)) = K1 a
+
+instance GOverride' i xs U1 where
+  type OverrideRep i xs U1 = U1
   overrideFrom U1 = U1
   overrideTo U1 = U1
+
+data Inspect =
+  Inspect
+    (Maybe Symbol) -- ^ Constructor name
+    (Maybe Symbol) -- ^ Selector name
+    (Maybe Nat)    -- ^ Selector index
+
+type EmptyInspect = 'Inspect 'Nothing 'Nothing 'Nothing
 
 -- | Type family used to determine which override from @xs@
 -- to replace @a@ with, if any. The @ms@ holds the field name
 -- for @a@, if applicable.
-type family Using (ms :: Maybe Symbol) (a :: *) (xs :: [*]) where
+type family Using (i :: Inspect) (a :: *) (xs :: [*]) where
   -- No matching override found.
-  Using ms a '[] = a
+  Using i a '[] = a
 
   -- Override the matching field.
-  Using ('Just o) a (As o n ': xs) = n
-  Using ('Just o) a (With o w ': xs) = w a
+  Using ('Inspect mc ('Just o) mp) a (As o n ': xs) = n
+  Using ('Inspect mc ('Just o) mp) a (With o w ': xs) = w a
 
   -- Override the matching type.
-  Using ms a (As a n ': xs) = n
-  Using ms a (With a w ': xs) = w a
+  Using i a (With a w ': xs) = w a
 
-  -- Override the matching kind (up to 10).
-  Using ms (f a0) (As f g ': xs) = g a0
-  Using ms (f a0 a1) (As f g ': xs) = g a0 a1
-  Using ms (f a0 a1 a2) (As f g ': xs) = g a0 a1 a2
-  Using ms (f a0 a1 a2 a3) (As f g ': xs) = g a0 a1 a2 a3
-  Using ms (f a0 a1 a2 a3 a4) (As f g ': xs) = g a0 a1 a2 a3 a4
-  Using ms (f a0 a1 a2 a3 a4 a5) (As f g ': xs) = g a0 a1 a2 a3 a4 a5
-  Using ms (f a0 a1 a2 a3 a4 a5 a6) (As f g ': xs) = g a0 a1 a2 a3 a4 a5 a6
-  Using ms (f a0 a1 a2 a3 a4 a5 a6 a7) (As f g ': xs) = g a0 a1 a2 a3 a4 a5 a6 a7
-  Using ms (f a0 a1 a2 a3 a4 a5 a6 a7 a8) (As f g ': xs) = g a0 a1 a2 a3 a4 a5 a6 a7 a8
-  Using ms (f a0 a1 a2 a3 a4 a5 a6 a7 a8 a9) (As f g ': xs) = g a0 a1 a2 a3 a4 a5 a6 a7 a8 a9
+  -- Override the matching type (type arity 0-10).
+  Using i a (As a n ': xs) = n
+  Using i (f a0) (As f g ': xs) = g a0
+  Using i (f a0 a1) (As f g ': xs) = g a0 a1
+  Using i (f a0 a1 a2) (As f g ': xs) = g a0 a1 a2
+  Using i (f a0 a1 a2 a3) (As f g ': xs) = g a0 a1 a2 a3
+  Using i (f a0 a1 a2 a3 a4) (As f g ': xs) = g a0 a1 a2 a3 a4
+  Using i (f a0 a1 a2 a3 a4 a5) (As f g ': xs) = g a0 a1 a2 a3 a4 a5
+  Using i (f a0 a1 a2 a3 a4 a5 a6) (As f g ': xs) = g a0 a1 a2 a3 a4 a5 a6
+  Using i (f a0 a1 a2 a3 a4 a5 a6 a7) (As f g ': xs) = g a0 a1 a2 a3 a4 a5 a6 a7
+  Using i (f a0 a1 a2 a3 a4 a5 a6 a7 a8) (As f g ': xs) = g a0 a1 a2 a3 a4 a5 a6 a7 a8
+  Using i (f a0 a1 a2 a3 a4 a5 a6 a7 a8 a9) (As f g ': xs) = g a0 a1 a2 a3 a4 a5 a6 a7 a8 a9
+
+  -- Override the matching constructor parameter.
+  Using ('Inspect ('Just c) ms ('Just p)) a (At c p n ': xs) = n
 
   -- No match on this override, recurse.
-  Using ms a (x ': xs) = Using ms a xs
+  Using i a (x ': xs) = Using i a xs

--- a/generic-override/src/Data/Override/Internal.hs
+++ b/generic-override/src/Data/Override/Internal.hs
@@ -79,7 +79,10 @@ class GOverride' (i :: Inspect) (xs :: [*]) (f :: * -> *) where
 instance (GOverride' i xs f) => GOverride' i xs (M1 D c f) where
   type OverrideRep i xs (M1 D c f) = M1 D c (OverrideRep i xs f)
   overrideFrom (M1 x) = M1 (overrideFrom @i @xs x)
+  {-# INLINE overrideFrom #-}
+
   overrideTo (M1 x) = M1 (overrideTo @i @xs x)
+  {-# INLINE overrideTo #-}
 
 instance
   ( GOverride' ('Inspect ('Just conName) ms mp) xs f
@@ -93,7 +96,10 @@ instance
             (OverrideRep ('Inspect ('Just conName) ms mp) xs f)
 
   overrideFrom (M1 x) = M1 (overrideFrom @('Inspect ('Just conName) ms mp) @xs x)
+  {-# INLINE overrideFrom #-}
+
   overrideTo (M1 x) = M1 (overrideTo @('Inspect ('Just conName) ms mp) @xs x)
+  {-# INLINE overrideTo #-}
 
 instance
   ( GOverride' ('Inspect mc ms ('Just 0)) xs f
@@ -107,10 +113,12 @@ instance
   overrideFrom (f :*: g) =
     overrideFrom @('Inspect mc ms ('Just 0)) @xs f
       :*: overrideFrom @('Inspect mc ms ('Just 1)) @xs g
+  {-# INLINE overrideFrom #-}
 
   overrideTo (f :*: g) =
     overrideTo @('Inspect mc ms ('Just 0)) @xs f
       :*: overrideTo @('Inspect mc ms ('Just 1)) @xs g
+  {-# INLINE overrideTo #-}
 
 instance
   ( GOverride' ('Inspect mc ms ('Just p)) xs f
@@ -124,10 +132,12 @@ instance
   overrideFrom (f :*: g) =
     overrideFrom @('Inspect mc ms ('Just p)) @xs f
       :*: overrideFrom @('Inspect mc ms ('Just (p + 1))) @xs g
+  {-# INLINE overrideFrom #-}
 
   overrideTo (f :*: g) =
     overrideTo @('Inspect mc ms ('Just p)) @xs f
       :*: overrideTo @('Inspect mc ms ('Just (p + 1))) @xs g
+  {-# INLINE overrideTo #-}
 
 instance
   ( GOverride' i xs f
@@ -139,10 +149,12 @@ instance
   overrideFrom = \case
     L1 f -> L1 $ overrideFrom @i @xs f
     R1 g -> R1 $ overrideFrom @i @xs g
+  {-# INLINE overrideFrom #-}
 
   overrideTo = \case
     L1 f -> L1 $ overrideTo @i @xs f
     R1 g -> R1 $ overrideTo @i @xs g
+  {-# INLINE overrideTo #-}
 
 instance
   ( GOverride' ('Inspect mc selName mp) xs f
@@ -152,7 +164,10 @@ instance
     M1 S ('MetaSel selName selSU selSS selDS) (OverrideRep ('Inspect mc selName mp) xs f)
 
   overrideFrom (M1 x) = M1 (overrideFrom @('Inspect mc selName mp) @xs x)
+  {-# INLINE overrideFrom #-}
+
   overrideTo (M1 x) = M1 (overrideTo @('Inspect mc selName mp) @xs x)
+  {-# INLINE overrideTo #-}
 
 instance
   ( Coercible a (Using ('Inspect mc ms ('Just 0)) a xs)
@@ -162,8 +177,10 @@ instance
     K1 R (Using ('Inspect mc ms ('Just 0)) a xs)
 
   overrideFrom (K1 a) = K1 (coerce a :: Using ('Inspect mc ms ('Just 0)) a xs)
+  {-# INLINE overrideFrom #-}
 
   overrideTo (K1 u) = K1 (coerce u :: a)
+  {-# INLINE overrideTo #-}
 
 instance
   ( Coercible a (Using ('Inspect mc ms ('Just p)) a xs)
@@ -173,13 +190,18 @@ instance
     K1 R (Using ('Inspect mc ms ('Just p)) a xs)
 
   overrideFrom (K1 a) = K1 (coerce a :: Using ('Inspect mc ms ('Just p)) a xs)
+  {-# INLINE overrideFrom #-}
 
   overrideTo (K1 u) = K1 (coerce u :: a)
+  {-# INLINE overrideTo #-}
 
 instance GOverride' i xs U1 where
   type OverrideRep i xs U1 = U1
   overrideFrom U1 = U1
+  {-# INLINE overrideFrom #-}
+
   overrideTo U1 = U1
+  {-# INLINE overrideTo #-}
 
 data Inspect =
   Inspect

--- a/generic-override/test/Encode.hs
+++ b/generic-override/test/Encode.hs
@@ -10,9 +10,8 @@
 {-# LANGUAGE UndecidableInstances #-}
 module Encode where
 
-import Data.Coerce
-import Data.List
-import Data.Override.Internal
+import Data.List (intercalate)
+import Data.Override.Internal (GOverride, Override)
 import GHC.Generics
 
 class Encode a where

--- a/generic-override/test/Encode.hs
+++ b/generic-override/test/Encode.hs
@@ -26,14 +26,6 @@ instance
   , GEncode (Rep (Override a xs))
   ) => Encode (Override a xs)
 
-instance
-  ( u ~ Using ms a xs
-  , Coercible a u
-  , Encode u
-  ) => Encode (Overridden ms a xs)
-  where
-  encode = encode @u . coerce
-
 class GEncode f where
   gencode :: f a -> String
 

--- a/generic-override/test/Test.hs
+++ b/generic-override/test/Test.hs
@@ -7,9 +7,9 @@
 {-# LANGUAGE TypeOperators #-}
 module Main where
 
-import Data.Monoid
-import Data.Override
-import Encode
+import Data.Monoid (Any(..))
+import Data.Override (Override(..), As, At)
+import Encode (Encode(encode), ListOf(..))
 import GHC.Generics (Generic)
 import Test.Hspec
 


### PR DESCRIPTION
generic-override
* `At` support for overriding by constructor name and parameter index
* Simplify encoding by removing `Overridden`
* Implementation of `Generic` derivation a la `GOverride` now use `INLINE`

generic-override-aeson
* Add `WithAesonOptions` support
* Bumping dependency bounds to support generic-override 0.4
* Because this version of generic-override no longer uses `Overridden` under
    the hood, this solves a problem where `omitNothingFields` had no effect
    due to aeson's incoherent `Maybe` instance not being solved. The new
    encoding solves this problem and `omitNothingFields` works as expected.
